### PR TITLE
Fix Discord webhook file attachment field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ view and notifying upon movement.
           "username": "NoOneIsSafe",
           "text_suffix": "From anonymous with love.",
           "max_file_mb": 8,
+          "user_agent": "curl/8.6.0",
           "timeout_sec": 10
         }
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ view and notifying upon movement.
           "webhook_url": "https://discord.com/api/webhooks/<id>/<token>",
           "username": "NoOneIsSafe",
           "text_suffix": "From anonymous with love.",
+          "max_file_mb": 8,
           "timeout_sec": 10
         }
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ view and notifying upon movement.
           "webhook_url": "https://discord.com/api/webhooks/<id>/<token>",
           "username": "NoOneIsSafe",
           "text_suffix": "From anonymous with love.",
-          "user_agent": "curl/8.6.0",
           "timeout_sec": 10
         }
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ view and notifying upon movement.
           "timeout_sec": 10
         }
 
+    Discord webhook uploads are limited to 8 MiB per file in this app.
+    Files above that limit are skipped.
+
     Telegram and Discord providers upload actual media files when present.
 
 4. Let the program run and do its magic:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ view and notifying upon movement.
           "webhook_url": "https://discord.com/api/webhooks/<id>/<token>",
           "username": "NoOneIsSafe",
           "text_suffix": "From anonymous with love.",
-          "max_file_mb": 8,
           "user_agent": "curl/8.6.0",
           "timeout_sec": 10
         }

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -5,6 +5,7 @@ from ..utils import post_multipart
 
 
 logger = logging.getLogger(__name__)
+DISCORD_WEBHOOK_MAX_FILE_SIZE = 8 * 2**20  # 8 MiB per attachment
 
 
 def send_discord(img_path, vid_path, message, discord_config):
@@ -28,6 +29,20 @@ def send_discord(img_path, vid_path, message, discord_config):
         msg = f'no files to send via discord for {img_path} and {vid_path}'
         logger.error(msg)
         raise FileNotFoundError(msg)
+    allowed_paths = []
+    for file_path in file_paths:
+        if file_path.stat().st_size > DISCORD_WEBHOOK_MAX_FILE_SIZE:
+            logger.warning(
+                'discord file %s is bigger than webhook limit (8 MiB), skipping',
+                file_path,
+            )
+            continue
+        allowed_paths.append(file_path)
+    if not allowed_paths:
+        msg = f'no files under Discord webhook size limit for {img_path}, {vid_path}'
+        logger.error(msg)
+        raise ValueError(msg)
+
     text_suffix = discord_config.get('text_suffix', 'From anonymous with love.')
     base_payload = {'content': f'{message}\n{text_suffix}'}
     if 'username' in discord_config:
@@ -35,7 +50,7 @@ def send_discord(img_path, vid_path, message, discord_config):
     if 'avatar_url' in discord_config:
         base_payload['avatar_url'] = discord_config['avatar_url']
 
-    for index, file_path in enumerate(file_paths):
+    for index, file_path in enumerate(allowed_paths):
         payload = dict(base_payload)
         if index > 0:
             payload['content'] = None

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -15,6 +15,7 @@ def send_discord(img_path, vid_path, message, discord_config):
         raise ValueError(msg)
 
     timeout = discord_config.get('timeout_sec', 10)
+    user_agent = discord_config.get('user_agent', 'curl/8.6.0')
     max_file_mb = discord_config.get('max_file_mb', DEFAULT_MAX_FILE_MB)
     file_paths = []
     if img_path.exists():
@@ -62,6 +63,10 @@ def send_discord(img_path, vid_path, message, discord_config):
             {'payload_json': json.dumps(payload)},
             [('files[0]', file_path)],
             timeout,
+            headers={
+                'User-Agent': user_agent,
+                'Accept': 'application/json',
+            },
         )
         logger.info('discord file %s delivered with status %s',
                     file_path, status)

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -27,7 +27,7 @@ def send_discord(img_path, vid_path, message, discord_config):
         msg = f'no files to send via discord for {img_path} and {vid_path}'
         logger.error(msg)
         raise FileNotFoundError(msg)
-    files = [(f'files[{i}]', path) for i, path in enumerate(file_paths)]
+    files = [(f'file{i + 1}', path) for i, path in enumerate(file_paths)]
 
     text_suffix = discord_config.get('text_suffix', 'From anonymous with love.')
     payload = {'content': f'{message}\n{text_suffix}'}

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -6,6 +6,7 @@ from ..utils import post_multipart
 
 logger = logging.getLogger(__name__)
 DISCORD_WEBHOOK_MAX_FILE_SIZE = 8 * 2**20  # 8 MiB per attachment
+DISCORD_USER_AGENT = 'curl/8.6.0'
 
 
 def send_discord(img_path, vid_path, message, discord_config):
@@ -15,7 +16,6 @@ def send_discord(img_path, vid_path, message, discord_config):
         raise ValueError(msg)
 
     timeout = discord_config.get('timeout_sec', 10)
-    user_agent = discord_config.get('user_agent', 'curl/8.6.0')
     file_paths = []
     if img_path.exists():
         file_paths.append(img_path)
@@ -60,7 +60,7 @@ def send_discord(img_path, vid_path, message, discord_config):
             [('files[0]', file_path)],
             timeout,
             headers={
-                'User-Agent': user_agent,
+                'User-Agent': DISCORD_USER_AGENT,
                 'Accept': 'application/json',
             },
         )

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -27,7 +27,7 @@ def send_discord(img_path, vid_path, message, discord_config):
         msg = f'no files to send via discord for {img_path} and {vid_path}'
         logger.error(msg)
         raise FileNotFoundError(msg)
-    files = [(f'file{i + 1}', path) for i, path in enumerate(file_paths)]
+    files = [(f'files[{i}]', path) for i, path in enumerate(file_paths)]
 
     text_suffix = discord_config.get('text_suffix', 'From anonymous with love.')
     payload = {'content': f'{message}\n{text_suffix}'}

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -5,7 +5,6 @@ from ..utils import post_multipart
 
 
 logger = logging.getLogger(__name__)
-DEFAULT_MAX_FILE_MB = 8
 
 
 def send_discord(img_path, vid_path, message, discord_config):
@@ -16,7 +15,6 @@ def send_discord(img_path, vid_path, message, discord_config):
 
     timeout = discord_config.get('timeout_sec', 10)
     user_agent = discord_config.get('user_agent', 'curl/8.6.0')
-    max_file_mb = discord_config.get('max_file_mb', DEFAULT_MAX_FILE_MB)
     file_paths = []
     if img_path.exists():
         file_paths.append(img_path)
@@ -30,23 +28,6 @@ def send_discord(img_path, vid_path, message, discord_config):
         msg = f'no files to send via discord for {img_path} and {vid_path}'
         logger.error(msg)
         raise FileNotFoundError(msg)
-    max_file_size = max_file_mb * 2**20
-    filtered_paths = []
-    for file_path in file_paths:
-        if file_path.stat().st_size > max_file_size:
-            logger.warning(
-                'discord file %s is bigger than %s MB, skipping',
-                file_path,
-                max_file_mb,
-            )
-            continue
-        filtered_paths.append(file_path)
-    if not filtered_paths:
-        msg = (f'no files small enough to send via discord for '
-               f'{img_path} and {vid_path}')
-        logger.error(msg)
-        raise ValueError(msg)
-
     text_suffix = discord_config.get('text_suffix', 'From anonymous with love.')
     base_payload = {'content': f'{message}\n{text_suffix}'}
     if 'username' in discord_config:
@@ -54,7 +35,7 @@ def send_discord(img_path, vid_path, message, discord_config):
     if 'avatar_url' in discord_config:
         base_payload['avatar_url'] = discord_config['avatar_url']
 
-    for index, file_path in enumerate(filtered_paths):
+    for index, file_path in enumerate(file_paths):
         payload = dict(base_payload)
         if index > 0:
             payload['content'] = None

--- a/nooneissafe/notification_providers/discord.py
+++ b/nooneissafe/notification_providers/discord.py
@@ -5,6 +5,7 @@ from ..utils import post_multipart
 
 
 logger = logging.getLogger(__name__)
+DEFAULT_MAX_FILE_MB = 8
 
 
 def send_discord(img_path, vid_path, message, discord_config):
@@ -14,6 +15,7 @@ def send_discord(img_path, vid_path, message, discord_config):
         raise ValueError(msg)
 
     timeout = discord_config.get('timeout_sec', 10)
+    max_file_mb = discord_config.get('max_file_mb', DEFAULT_MAX_FILE_MB)
     file_paths = []
     if img_path.exists():
         file_paths.append(img_path)
@@ -27,19 +29,40 @@ def send_discord(img_path, vid_path, message, discord_config):
         msg = f'no files to send via discord for {img_path} and {vid_path}'
         logger.error(msg)
         raise FileNotFoundError(msg)
-    files = [(f'files[{i}]', path) for i, path in enumerate(file_paths)]
+    max_file_size = max_file_mb * 2**20
+    filtered_paths = []
+    for file_path in file_paths:
+        if file_path.stat().st_size > max_file_size:
+            logger.warning(
+                'discord file %s is bigger than %s MB, skipping',
+                file_path,
+                max_file_mb,
+            )
+            continue
+        filtered_paths.append(file_path)
+    if not filtered_paths:
+        msg = (f'no files small enough to send via discord for '
+               f'{img_path} and {vid_path}')
+        logger.error(msg)
+        raise ValueError(msg)
 
     text_suffix = discord_config.get('text_suffix', 'From anonymous with love.')
-    payload = {'content': f'{message}\n{text_suffix}'}
+    base_payload = {'content': f'{message}\n{text_suffix}'}
     if 'username' in discord_config:
-        payload['username'] = discord_config['username']
+        base_payload['username'] = discord_config['username']
     if 'avatar_url' in discord_config:
-        payload['avatar_url'] = discord_config['avatar_url']
-    status = post_multipart(
-        discord_config['webhook_url'],
-        {'payload_json': json.dumps(payload)},
-        files,
-        timeout,
-    )
-    logger.info('discord notification delivered with status %s', status)
+        base_payload['avatar_url'] = discord_config['avatar_url']
+
+    for index, file_path in enumerate(filtered_paths):
+        payload = dict(base_payload)
+        if index > 0:
+            payload['content'] = None
+        status = post_multipart(
+            discord_config['webhook_url'],
+            {'payload_json': json.dumps(payload)},
+            [('files[0]', file_path)],
+            timeout,
+        )
+        logger.info('discord file %s delivered with status %s',
+                    file_path, status)
 

--- a/nooneissafe/utils.py
+++ b/nooneissafe/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import mimetypes
+import urllib.error
 import urllib.request
 import uuid
 
@@ -87,5 +88,11 @@ def post_multipart(url, fields, files, timeout):
         headers={'Content-Type': content_type},
         method='POST',
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        return response.status
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        body = error.read().decode('utf-8', errors='replace')
+        raise RuntimeError(
+            f'HTTP {error.code} while posting multipart to {url}: {body}'
+        ) from error

--- a/nooneissafe/utils.py
+++ b/nooneissafe/utils.py
@@ -80,12 +80,15 @@ def _encode_multipart_form_data(fields, files):
     return bytes(body), content_type
 
 
-def post_multipart(url, fields, files, timeout):
+def post_multipart(url, fields, files, timeout, headers=None):
     body, content_type = _encode_multipart_form_data(fields, files)
+    request_headers = {'Content-Type': content_type}
+    if headers:
+        request_headers.update(headers)
     request = urllib.request.Request(
         url,
         data=body,
-        headers={'Content-Type': content_type},
+        headers=request_headers,
         method='POST',
     )
     try:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep Discord multipart field naming aligned with working curl pattern (`files[0]`)
- send Discord attachments one-by-one to avoid a single bad file causing full request failure
- improve multipart HTTP error reporting to include response body in exception messages (helps diagnose 403s)
- enforce a fixed non-configurable Discord `User-Agent` (`curl/8.6.0`)
- enforce a fixed non-configurable Discord webhook file limit of 8 MiB per attachment
- skip files above 8 MiB with warning logs
- update README Discord section with fixed non-configurable behavior

## Testing
- `python3 -m compileall nooneissafe`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a2277e6-ba56-432b-960c-2d5010f3d549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a2277e6-ba56-432b-960c-2d5010f3d549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

