### PR TITLE
Tighten motion detection thresholds to reduce false positives

### DIFF
--- a/nooneissafe/utils.py
+++ b/nooneissafe/utils.py
@@ -36,10 +36,10 @@ class MotionDetector:
     def __init__(
         self,
         history=200,
-        var_threshold=32,
-        min_contour_area=900,
-        min_motion_ratio=0.003,
-        required_motion_frames=2,
+        var_threshold=40,
+        min_contour_area=1500,
+        min_motion_ratio=0.005,
+        required_motion_frames=3,
         warmup_frames=3,
     ):
         self.min_contour_area = min_contour_area


### PR DESCRIPTION
## Summary
- `var_threshold`: 32 → 40 — MOG2 less sensitive to pixel noise
- `min_contour_area`: 900 → 1500 — ignore small spurious blobs
- `min_motion_ratio`: 0.003 → 0.005 — require more pixels in motion
- `required_motion_frames`: 2 → 3 — need sustained motion before triggering

## Test plan
- [ ] Run with a static scene and verify no false triggers
- [ ] Verify real movement (person walking) still triggers detection
- [ ] Check logs for `motion_ratio` and `changed_pixels` values to confirm thresholds are reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)